### PR TITLE
fix(transactions): handle decimal price formatting correctly for Tran…

### DIFF
--- a/stock-trading-system/src/components/TransactionsModal.jsx
+++ b/stock-trading-system/src/components/TransactionsModal.jsx
@@ -80,8 +80,9 @@ const TransactionsModal = ({
                   <td className="px-3 py-2 text-sm">{tx.TransactionType}</td>
                   <td className="px-3 py-2 text-sm text-right">{tx.Quantity}</td>
                   <td className="px-3 py-2 text-sm text-right">
-                    {tx.Price != null ? `$${tx.Price.toFixed(2)}` : "-"} {/* ✅ Safer */}
+                       {tx.Price != null ? `$${parseFloat(tx.Price).toFixed(2)}` : "-"}
                   </td>
+
                   <td className="px-3 py-2 text-sm">
                     {new Date(tx.Timestamp).toLocaleString()}
                   </td>


### PR DESCRIPTION
…sactionsModal

- Fixed issue where Price was returned as a string from MySQL causing .toFixed() errors
- Applied parseFloat() before using .toFixed(2) for safe rendering
- Transactions now load and display correctly without frontend crash